### PR TITLE
Convert from Moq to NSubstitute

### DIFF
--- a/test/Autofac.Integration.AspNetCore.Test/Autofac.Integration.AspNetCore.Test.csproj
+++ b/test/Autofac.Integration.AspNetCore.Test/Autofac.Integration.AspNetCore.Test.csproj
@@ -27,7 +27,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/test/Autofac.Integration.AspNetCore.Test/AutofacWebHostBuilderExtensionsTests.cs
+++ b/test/Autofac.Integration.AspNetCore.Test/AutofacWebHostBuilderExtensionsTests.cs
@@ -2,7 +2,7 @@
 using Autofac.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace Autofac.Integration.AspNetCore.Test
@@ -12,13 +12,12 @@ namespace Autofac.Integration.AspNetCore.Test
         [Fact]
         public void UseAutofacAddsFactoryProviderToServiceCollection()
         {
-            var webHostBuilder = new Mock<IWebHostBuilder>();
+            var webHostBuilder = Substitute.For<IWebHostBuilder>();
 
             Action<IServiceCollection> serviceAction = null;
-            webHostBuilder.Setup(x => x.ConfigureServices(It.IsAny<Action<IServiceCollection>>()))
-                .Callback<Action<IServiceCollection>>(s => serviceAction = s);
+            webHostBuilder.ConfigureServices(Arg.Do<Action<IServiceCollection>>(s => serviceAction = s));
 
-            webHostBuilder.Object.UseAutofac(b => b.RegisterInstance("Foo"));
+            webHostBuilder.UseAutofac(b => b.RegisterInstance("Foo"));
 
             var services = new ServiceCollection();
             serviceAction(services);


### PR DESCRIPTION
## Summary
- Replace Moq with NSubstitute 5.3.0
- Convert `Mock<IWebHostBuilder>` with Setup/Callback to NSubstitute `Arg.Do<T>()` pattern
- Part of cross-repo effort to standardize on NSubstitute

## Test plan
- [x] Build succeeds locally
- [x] Test passes locally